### PR TITLE
Task 2

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -1,5 +1,5 @@
 from project import db, app
-
+from project.safe import SafeValue
 
 # Customer model
 class Customer(db.Model):
@@ -22,7 +22,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {SafeValue(self.city)}, Age: {self.age}, Pesel: {SafeValue(self.pesel)}, Street: {SafeValue(self.street)}, AppNo: {(self.appNo)})"
 
 
 with app.app_context():

--- a/Python/Flask_Book_Library/project/safe.py
+++ b/Python/Flask_Book_Library/project/safe.py
@@ -1,0 +1,14 @@
+class SafeValue:
+    """A type wrapper that doesn't show its content in str(), format() or repr().
+    """
+    def __init__(self, value):
+        type(value).__init__(value)
+
+    def __format__(self, _spec):
+        return "****"
+
+    def __str__(self):
+        return "****"
+
+    def __repr__(self):
+        return "****"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Security By Design - Zadanie 1
+# Security By Design - Zadanie 1 
 
 ## Wymagania
 1. Zainstalowana komenda `git` na stacji roboczej


### PR DESCRIPTION
# Zadanie 1

Fragment logów aplikacji:

```
Customers page accessed
Getting: Customer(ID: None, Name: Jan Szot, City: Warszawa, Age: 18, Pesel: 02345928334, Street: Królewska, AppNo: 11)
```

Każde dodanie użytkownika powoduje zapis *wszystkich* danych do logów aplikacji, w tym wrażliwych danych osobowych jak numer PESEL i adres. Po wprowadzeniu zmian w kodzie, zapis wygląda następująco:

```
Customers page accessed
Getting: Customer(ID: None, Name: Jan Szot, City: ****, Age: 18, Pesel: ****, Street: ****, AppNo: ****)
```


# Zadanie 2

Użyto polecenie `docker run -v ${path_to_host_folder_to_scan}:/path zricethezav/gitleaks:latest detect --source="/path" -v`.

```
# Fingerprint format: commit-hash:filename:type:line
[...]
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:deployment.key:private-key:1
[...]
Fingerprint: de9d7b8cb63bd7ae741ec5c9e23891b71709bc28:deployment2.key:private-key:1
[...]
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:awscredentials.json:private-key:5
[...]
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:awscredentials.json:generic-api-key:4

5:31PM INF 6 commits scanned.
5:31PM INF scan completed in 1.34s
5:31PM WRN leaks found: 4
```

Narzędzie `gitleaks` wykryło 4 sekrety w historii repozytorium: 3 z kategorii "private-key" i 1 "generic-api-key". Oznaczone commity to [de9d7b8](https://github.com/Mixeway-Academy/task2/commit/de9d7b8cb63bd7ae741ec5c9e23891b71709bc28) i [bc17b7d](https://github.com/Mixeway-Academy/task2/commit/bc17b7ddc46f46fff175aed55d68e11bb48166cc). W rzeczywistości wyciekły 2 klucze:
* zmodyfikowany i potem zduplikowany (`deployment2.key`, `deployment.key`),
* drugi w pliku `awscredentials.json`, udający dane logujące do AWS. Dane w tym pliku nie pasują do formatu stosowanego przez Amazon ([link](https://summitroute.com/blog/2018/06/20/aws_security_credential_formats/)), więc dostęp do platformy AWS nie jest zagrożony. Z tego powodu sekret typu `generic-api-key` można uznać za przypadek *false positive* (plus ID klucza dostępu nie jest informacją wrażliwą).

Oprócz tego, w kodzie znajdują się dwa sekrety nie znalezione przez narzędzie:
* w [`Dockerfile`](https://github.com/Mixeway-Academy/task2/blob/main/Python/Flask_Book_Library/Dockerfile#L10): `ENV PASSWORD=1qaz@WSX`,
* w [`project/__init__.py`](https://github.com/Mixeway-Academy/task2/blob/main/Python/Flask_Book_Library/project/__init__.py#L10): `app.config['SECRET_KEY'] = 'supersecret' # To allow us to use forms`.

Sposoby bezpiecznego przechowywania sekretów:
* wykorzystywanie zewnętrznych usług, np. [GitHub](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions), [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), [Azure Key Valut](https://azure.microsoft.com/en-us/products/key-vault/), [HashiCorp Vault](https://www.vaultproject.io).
* trzymanie sekretów w zmiennych środowiskowych maszyny lokalnej - jest to bezpieczne rozwiązanie, lecz synchronizacja/zmiana sekretów wymaga komunikacji innymi kanałami.
* szyfrowanie sekretów (i *nie* publikowanie kluczy).

# Zadanie 3

Wynik polecenia `docker run -it -v ${path_to_host_folder_to_scan}:/sources pyupio/safety safety check -r /sources/requirements-task.txt --full-report`:

```
+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 18 packages, using free DB (updated once a month)                    |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| healpy                     | 1.8.0     | <=1.16.6                 | 61774    |
+==============================================================================+
| Healpy 1.16.6 and prior releases ship with a version of 'libcurl' that has a |
| high-severity vulnerability.                                                 |
+==============================================================================+
```

Znaleziono jeden pakiet zawierający podatności: [healpy](https://pypi.org/project/healpy/). Podsumowanie na ten temat dostarczone przez PyUp: "Healpy 1.16.6 and prior releases ship with a version of 'libcurl' that has a high-severity vulnerability.".

* CVE: [CVE-2023-38545](https://nvd.nist.gov/vuln/detail/CVE-2023-38545)
* Krytyczność: 9.8 (Critical)
* Luka: [CWE-787 Out-of-bounds Write](https://cwe.mitre.org/data/definitions/787.html)
* Potencjalne wykorzystanie: "It's undefined behavior at best and *possible* RCE at worst." ([HackerOne](https://hackerone.com/reports/2187833))

**Pakiet ten nie jest wykorzystywany nigdzie w projekcie. Ponadto, pakiet `healpy` nie wykorzystuje bezpośrednio biblioteki `libcurl`, która jest dołączona do biblioteki `cfitsio` ([link](https://www.github.com/healpy/healpy/issues/758#issuecomment-1092034139)). Podatność nie stwarza zagrożenia w kontekście projektu, ale zalecane jest jak najszybsze usunięcie pakietu healpy ze względu na wysoką krytyczność podatności i fakt, że do tego czasu (18.11.2023) nie została usunięta ([link](https://www.github.com/healpy/healpy/issues/758#issuecomment-1092030458)).**
